### PR TITLE
plan-feature-fix: Date popup dependency missing

### DIFF
--- a/sites/all/modules/custom/features/plan/plan.info
+++ b/sites/all/modules/custom/features/plan/plan.info
@@ -4,6 +4,7 @@ core = 7.x
 package = PM
 version = 7.x-1.0
 dependencies[] = date
+dependencies[] = date_popup
 dependencies[] = entityreference
 dependencies[] = features
 dependencies[] = options


### PR DESCRIPTION
@d2ev - We need to add `date popup` module as a dependency for the feature: `plan`.

cc: @monikamisra  @boyinasantosh 
