### PR TITLE
plus_tapi: API service to make calls to other websites.

### DIFF
--- a/sites/all/modules/custom/plus_tapi/plus_tapi.admin.inc
+++ b/sites/all/modules/custom/plus_tapi/plus_tapi.admin.inc
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @file
+ * Everything related to plus_tapi's Admin.
+ */
+
+/**
+ * Implements hook_form.
+ */
+function plus_tapi_config_form() {
+  $item = array();
+
+  $item['plus_tapi'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Plus7 TAPI Configuration'),
+    '#collapsible' => TRUE,
+    '#collapsed' => FALSE,
+  );
+
+  $item['plus_tapi']['plus_tapi_request_method'] = array(
+    '#type' => 'select',
+    '#required' => TRUE,
+    '#options' => array(
+      '' => 'Select',
+      'curl' => t('cURL'),
+      'http' => t('HTTP'),
+    ),
+    '#title' => t('Plus7 TAPI request method'),
+    '#default_value' => variable_get('plus_tapi_request_method', 'curl'),
+  );
+
+  return system_settings_form($item);
+}

--- a/sites/all/modules/custom/plus_tapi/plus_tapi.info
+++ b/sites/all/modules/custom/plus_tapi/plus_tapi.info
@@ -1,0 +1,11 @@
+name = Plus7 TAPI
+description = "Integrates with third party api based on ssl/curl."
+core = 7.x
+package = Plus7
+version = "7.x-1.0"
+
+dependencies[] = taxonomy_events
+
+files[] = plus_tapi.request.inc
+
+configure = admin/config/services/plus_tapi

--- a/sites/all/modules/custom/plus_tapi/plus_tapi.module
+++ b/sites/all/modules/custom/plus_tapi/plus_tapi.module
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Implements hook_permission.
+ */
+function plus_tapi_permission() {
+  return array(
+    'administer plus_tapi' => array(
+      'title' => t('Administer Plus7 TAPI Configuration'),
+    ),
+  );
+}
+
+/**
+ * Implements hook_menu.
+ */
+function plus_tapi_menu() {
+  $menu = array();
+
+  $menu['admin/config/services/plus_tapi'] = array(
+    'title' => 'Plus7 TAPI Configuration',
+    'description' => 'Set Plus7 TAPI configurations here.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('plus_tapi_config_form'),
+    'access arguments' => array('administer plus_tapi'),
+    'file' => 'plus_tapi.admin.inc',
+    'type' => MENU_NORMAL_ITEM,
+  );
+
+  return $menu;
+}
+
+/**
+ * Function to make API calls with other websites.
+ *
+ * @param $call
+ *  name of the API call being made.
+ * @param array $params
+ *  (optional) an associative array of parameters to be sent along with the call.
+ *  The key should be the name of the parameter iand the value of that key should
+ *  be the value to be passed for that parameter.
+ */
+function plus_tapi_request($type = 'movies', $call, $params = array()) {
+
+  $plus_tapi_request_method = variable_get('plus_tapi_request_method', 'curl');
+  $plus_tapi_function = $plus_tapi_request_method . '_request';
+
+  $type_resource = plus_tapi_get_resource($type);
+  if (!$type_resource) {
+    return FALSE;
+  }
+
+  // Wrapping taxonomy term data into entity.
+  $type_wrapper = entity_metadata_wrapper('taxonomy_term', $type_resource);
+
+  $call = $type_wrapper->field_api_url->value() . $call;
+
+  $options['params'] = $params;
+  if (!empty($type_wrapper->field_api_headers->value())) {
+    $options['headers'] = $type_wrapper->field_api_headers->value();
+  }
+
+  // Making TAPI request based on request method.
+  $plus_tapi_obj = new PlusTAPI();
+  $response = $plus_tapi_obj->{$plus_tapi_function}($call, $options);
+
+  return $response;
+}
+
+/**
+ * Function to return event type resource information.
+ *
+ * @param $type
+ *  name of the event: movies or dining
+ *
+ * @return object $resource or Boolean.
+ *   return taxonomy term data based on the provided term name.
+ */
+function plus_tapi_get_resource($type) {
+  $resource = taxonomy_get_term_by_name($type);
+  return (!empty($resource)) ? reset($resource) : FALSE;
+}

--- a/sites/all/modules/custom/plus_tapi/plus_tapi.request.inc
+++ b/sites/all/modules/custom/plus_tapi/plus_tapi.request.inc
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @file
+ * API for making call to TAPI.
+ */
+
+/**
+ * Request object for TAPI.
+ */
+class PlusTAPI {
+
+  function __construct() {
+    // TO DO
+  }
+
+  /**
+   * Performs an API request using HTTP method.
+   *
+   * @param $call
+   *  name of the API call being made.
+   * @param $options
+   *  (optional) an array taking the following keys:
+   *  - params: (optional) an associative array of parameters to be sent along with the call. The key should be the name of the parameter and the value of that key should be the value to be passed for that parameter.
+   * @return same as response returned by drupal_http_request().
+   */
+  function http_request($call, $options = array()) {
+    $params = array();
+    if (isset($options['params'])) {
+      foreach ($options['params'] as $param => $value) {
+        $params[$param] = $value;
+      }
+    }
+    $query = http_build_query($params);
+    $options['http_request_options'] = array();
+    if (!empty($options['headers'])) {
+      foreach ($options['headers'] as $header => $value) {
+        list($header_key, $header_value) = explode(":", $value);
+        $options['http_request_options']['headers'][$header_key] = $header_value;
+      }
+    }
+
+    $response = drupal_http_request($call . '?' . $query, $options['http_request_options']);
+
+    return $response;
+  }
+
+  /**
+   * Performs an API request using cURL method.
+   *
+   * @param $call
+   *  name of the API call being made.
+   * @param $options
+   *  (optional) an array taking the following keys:
+   *  - params: (optional) an associative array of parameters to be sent along with the call. The key should be the name of the parameter and the value of that key should be the value to be passed for that parameter.
+   * @return json formatted response returned by curl_exec().
+   */
+  function curl_request($call, $options = array()) {
+    $params = array();
+    if (!empty($options['params'])) {
+      foreach ($options['params'] as $param => $value) {
+        $params[$param] = $value;
+      }
+    }
+    $query = drupal_http_build_query($params);
+
+    if (!empty($options['headers'])) {
+      $customHeader = array();
+      foreach ($options['headers'] as $header => $value) {
+        $customHeader[] = $value;
+      }
+    }
+
+    $url = $call . '?' . $query;
+    $ch = curl_init($url);
+    $timeout = 0; // set to zero for no timeout
+    curl_setopt($ch, CURLOPT_URL, $url);
+    curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
+    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, $customHeader);
+    $response = curl_exec($ch);
+    curl_close($ch);
+
+    return drupal_json_decode($response);
+  }
+}


### PR DESCRIPTION
### Plus7 TAPI

Using `plus_tapi_request`, we can make calls to third party api to get the data. Calls are based on the request method: `cUrl` or `http`. 

As an administrator, we can configure request method at: `admin/config/services/plus_tapi`.

Example:

```
$data = plus_tapi_request('dining', 'cities', array('q' => 'hyd'));
/**
 * Explanation:
 *   dining: Denotes the event type. These are taxonomy terms.
 *   cities:  Denotes third party api request to pull the data.
 *   array(): Key-Value query parameters.
 */
```

Apart from the above function parameters, we will pull the other information like, `API URL` and `HEADER` information defined from the taxonomy term.

cc: @monikamisra @d2ev @boyinasantosh 
